### PR TITLE
emoticon handling

### DIFF
--- a/internal/pkg/structs/act.go
+++ b/internal/pkg/structs/act.go
@@ -84,6 +84,9 @@ type NcActSomeoneProduceMakeCmd struct {
 	Item   uint16
 }
 
+// Question: Why specify "SOMEONE" in the names here? Looks like it's
+// NC_ACT_JUMP_CMD so should we remove that part for clarity?
+
 // struct PROTO_NC_ACT_SOMEEONEJUMP_CMD
 type NcActSomeoneJumpCmd struct {
 	Handle uint16

--- a/internal/pkg/structs/emote.go
+++ b/internal/pkg/structs/emote.go
@@ -1,0 +1,8 @@
+package structs
+
+// struct PROTO_NC_ACT_EMOTICON_CMD
+type NcActEmoticonCmd struct {
+	Handle uint16
+}
+
+// TODO handle NC_ACT_EMOTICONSTOP_CMD

--- a/internal/zone/act_handlers.go
+++ b/internal/zone/act_handlers.go
@@ -83,6 +83,37 @@ func ncActMoveRunCmd(ctx context.Context, np *networking.Parameters) {
 	zm.events.send[playerRuns] <- &e
 }
 
+// NC_ACT_EMOTICON_CMD
+func ncActEmoticonCmd(ctx context.Context, np *networking.Parameters) {
+	var e playerEmotedEvent
+
+	session, ok := np.Session.(*session)
+
+	if !ok {
+		log.Error(errors.Err{
+			Code: errors.ZoneNoSessionAvailable,
+		})
+		return
+	}
+
+	e = playerEmotedEvent{
+		handle: session.handle,
+	}
+
+	zm, ok := maps.list[session.mapID]
+	if !ok {
+		log.Error(errors.Err{
+			Code: errors.ZoneMapNotFound,
+			Details: errors.Details{
+				"session": session,
+			},
+		})
+		return
+	}
+
+	zm.events.send[playerEmoted] <- &e
+}
+
 // NC_ACT_JUMP_CMD
 func ncActJumpCmd(ctx context.Context, np *networking.Parameters) {
 	var e playerJumpedEvent

--- a/internal/zone/events.go
+++ b/internal/zone/events.go
@@ -57,6 +57,7 @@ const (
 	playerDisappeared
 	playerWalks
 	playerRuns
+	playerEmoted
 	playerJumped
 	playerStopped
 	unknownHandle
@@ -102,7 +103,7 @@ var (
 		playerHandle,
 		playerHandleMaintenance,
 		queryPlayer, queryMonster,
-		playerAppeared, playerDisappeared, playerJumped, playerWalks, playerRuns, playerStopped,
+		playerAppeared, playerDisappeared, playerEmoted, playerJumped, playerWalks, playerRuns, playerStopped,
 		unknownHandle, monsterAppeared, monsterDisappeared, monsterWalks, monsterRuns,
 		playerSelectsEntity, playerUnselectsEntity, playerClicksOnNpc, playerPromptReply, itemIsMoved, itemEquip, itemUnEquip,
 	}

--- a/internal/zone/map_events.go
+++ b/internal/zone/map_events.go
@@ -27,6 +27,10 @@ type playerRunsEvent struct {
 	nc     *structs.NcActMoveRunCmd
 }
 
+type playerEmotedEvent struct {
+	handle uint16
+}
+
 type playerJumpedEvent struct {
 	handle uint16
 }

--- a/internal/zone/map_test.go
+++ b/internal/zone/map_test.go
@@ -46,7 +46,7 @@ func TestLoadMap(t *testing.T) {
 		playerHandle,
 		playerHandleMaintenance,
 		queryPlayer, queryMonster,
-		playerAppeared, playerDisappeared, playerJumped, playerWalks, playerRuns, playerStopped,
+		playerAppeared, playerDisappeared, playerEmoted, playerJumped, playerWalks, playerRuns, playerStopped,
 		unknownHandle, monsterAppeared, monsterDisappeared, monsterWalks, monsterRuns,
 		playerSelectsEntity, playerUnselectsEntity, playerClicksOnNpc, playerPromptReply, itemIsMoved, itemEquip, itemUnEquip,
 	}

--- a/internal/zone/map_workers.go
+++ b/internal/zone/map_workers.go
@@ -44,6 +44,8 @@ func (zm *zoneMap) playerActivity() {
 			go playerRunsLogic(e, zm)
 		case e := <-zm.events.recv[playerStopped]:
 			go playerStoppedLogic(e, zm)
+		case e := <-zm.events.recv[playerEmoted]:
+			go playerEmotedLogic(e, zm)
 		case e := <-zm.events.recv[playerJumped]:
 			go playerJumpedLogic(e, zm)
 		case e := <-zm.events.recv[unknownHandle]:
@@ -879,6 +881,26 @@ func playerStoppedLogic(e event, zm *zoneMap) {
 	}
 
 	mapEpicenterBroadcast(zm, p1, networking.NC_ACT_SOMEONESTOP_CMD, nc)
+}
+
+func playerEmotedLogic(e event, zm *zoneMap) {
+	ev, ok := e.(*playerEmotedEvent)
+	if !ok {
+		log.Error(eventTypeCastError(reflect.TypeOf(playerEmotedEvent{}).String(), reflect.TypeOf(ev).String()))
+		return
+	}
+
+	p1, err := zm.entities.getPlayer(ev.handle)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	nc := &structs.NcActEmoticonCmd{
+		Handle: ev.handle,
+	}
+
+	mapEpicenterBroadcast(zm, p1, networking.NC_ACT_EMOTICON_CMD, nc)
 }
 
 func playerJumpedLogic(e event, zm *zoneMap) {

--- a/internal/zone/serve.go
+++ b/internal/zone/serve.go
@@ -115,6 +115,9 @@ func Start(cmd *cobra.Command, args []string) {
 			networking.NC_ACT_MOVERUN_CMD: networking.ShinePacket{
 				Handler: ncActMoveRunCmd,
 			},
+			networking.NC_ACT_EMOTICON_CMD: networking.ShinePacket{
+				Handler: ncActEmoticonCmd,
+			},
 			networking.NC_ACT_JUMP_CMD: networking.ShinePacket{
 				Handler: ncActJumpCmd,
 			},


### PR DESCRIPTION
Just draft for my first real PR. This isn't fully done but seemed like a good first step. Currently if you try an emote you will see:

```
shineo_zone   | INFO : 2021/11/04 14:36:59.168200 networking.go:251: inbound NC_ACT_EMOTICON_CMD packet metadata: {"packetType":"small","length":3,"department":8,"command":"20","opCode":8224,"data":"07","rawData":"03202007","friendlyName":""}
shineo_zone   | ERROR: 2021/11/04 14:36:59.168508 handler.go:141: non existent handler for operation code  8224 NC_ACT_EMOTICON_CMD
shineo_zone   | INFO : 2021/11/04 14:37:00.883680 networking.go:251: inbound NC_ACT_EMOTICON_CMD packet metadata: {"packetType":"small","length":3,"department":8,"command":"20","opCode":8224,"data":"08","rawData":"03202008","friendlyName":""}
shineo_zone   | ERROR: 2021/11/04 14:37:00.883959 handler.go:141: non existent handler for operation code  8224 NC_ACT_EMOTICON_CMD
shineo_zone   | INFO : 2021/11/04 14:37:02.870229 networking.go:251: inbound NC_ACT_EMOTICON_CMD packet metadata: {"packetType":"small","length":3,"department":8,"command":"20","opCode":8224,"data":"09","rawData":"03202009","friendlyName":""}
shineo_zone   | ERROR: 2021/11/04 14:37:02.870495 handler.go:141: non existent handler for operation code  8224 NC_ACT_EMOTICON_CMD
```
this was me trying "Stand" > "Greet" > "Laugh", notice the change in `data` field to specify each one.

With the current changes, we technically *handle* them in the sense we don't get the `non existent handler` error, but nothing shows up in the client. 

I believe this is because we need to actually read from the appropriate SHN file and respond to the client request properly in order for the animation to begin.

If I look in the SHN file *ActionViewInfo*, I see: 
![image](https://user-images.githubusercontent.com/86197850/140564649-120a08c5-d6a5-48a5-897d-10a4adcb3799.png)
So this is how the data 07, 08, 09 correlates I suppose.

